### PR TITLE
Use lf for conan

### DIFF
--- a/conanfile_rtc.py
+++ b/conanfile_rtc.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from conans import ConanFile
 
 
@@ -8,11 +6,11 @@ class VkBootstrapConan(ConanFile):
     version = "1.3.283"
     url = "https://github.com/Esri/vk-bootstrap/blob/runtimecore/"
     license = "https://github.com/Esri/vk-bootstrap/blob/runtimecore/LICENSE.md"
-    description = ("A utility library that jump starts initialization of Vulkan")
-    
+    description = "A utility library that jump starts initialization of Vulkan"
+
     # RTC specific triple
     settings = "platform_architecture_target"
-    
+
     def package(self):
         base = self.source_folder + "/"
         relative = "3rdparty/vk-bootstrap/"


### PR DESCRIPTION
@ClowReed3288 we recently had a change on our build system that found that this file was committed using CRLF line endings and caused an issue with our conan recipes. You may want to double check your git settings on Windows to commit files using LF (default for cross platform development)